### PR TITLE
Fix Google login callback for remote hosts

### DIFF
--- a/frontend/src/view/auth/GoogleCallback.vue
+++ b/frontend/src/view/auth/GoogleCallback.vue
@@ -61,7 +61,7 @@ onMounted(async () => {
       const isClient = import.meta.env.VITE_IS_CLIENT === 'true';
       const redirectUri = isClient
       ? import.meta.env.VITE_GOOGLE_REDIRECT_URI_ELECTRON
-      : 'http://localhost:5005/api/users/auth/google'; // Electron 主进程处理
+      : `${window.location.origin}/api/users/auth/google`; // Electron 主进程处理
 
       // const redirectUri = 'http://localhost:5005/api/users/auth/google';
       console.log("redirectUri",redirectUri)

--- a/frontend/src/view/auth/Login.vue
+++ b/frontend/src/view/auth/Login.vue
@@ -294,8 +294,8 @@ const handleGoogleLogin = () => {
     loading.value = true;
     const isClient = import.meta.env.VITE_IS_CLIENT === 'true';
     const redirectUri = isClient
-      ? import.meta.env.VITE_GOOGLE_REDIRECT_URI_ELECTRON// Electron 主进程处理
-      : 'http://localhost:5005/api/users/auth/google'; 
+      ? import.meta.env.VITE_GOOGLE_REDIRECT_URI_ELECTRON // Electron 主进程处理
+      : `${window.location.origin}/api/users/auth/google`;
     const clientId = '973572698649-hbp15ju1nhlsja1k2gbqktmrulk0hopp.apps.googleusercontent.com';
     const scope = encodeURIComponent('profile email');
     const responseType = 'code';

--- a/src/routers/user/users.js
+++ b/src/routers/user/users.js
@@ -90,7 +90,8 @@ router.get('/auth/google', async (ctx) => {
     `;
   } else {
     // 不是客户端，直接重定向到前端页面
-    const redirectUrl = `http://localhost:5005/#/auth/google${queryString ? '?' + queryString : ''}`;
+    const frontendOrigin = process.env.FRONTEND_ORIGIN || ctx.origin;
+    const redirectUrl = `${frontendOrigin}/#/auth/google${queryString ? '?' + queryString : ''}`;
     ctx.redirect(redirectUrl);
   }
 });


### PR DESCRIPTION
## Summary
- make Google redirect page detect frontend host automatically
- use current origin for Google callback URLs in the SPA

## Testing
- `npm test` *(fails: mocha: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868cfcae6908321a507b184848d7e42