### PR TITLE
Fix Google login callback for remote hosts

### DIFF
--- a/frontend/src/view/auth/GoogleCallback.vue
+++ b/frontend/src/view/auth/GoogleCallback.vue
@@ -59,9 +59,10 @@ onMounted(async () => {
   if (urlParams.has('code')) {
     try {
       const isClient = import.meta.env.VITE_IS_CLIENT === 'true';
+      const redirectUriBase = import.meta.env.VITE_SERVICE_URL || window.location.origin;
       const redirectUri = isClient
       ? import.meta.env.VITE_GOOGLE_REDIRECT_URI_ELECTRON
-      : 'http://localhost:5005/api/users/auth/google'; // Electron 主进程处理
+      : `${redirectUriBase}/api/users/auth/google`; // Electron 主进程处理
 
       // const redirectUri = 'http://localhost:5005/api/users/auth/google';
       console.log("redirectUri",redirectUri)

--- a/frontend/src/view/auth/Login.vue
+++ b/frontend/src/view/auth/Login.vue
@@ -293,13 +293,15 @@ const handleGoogleLogin = () => {
   try {
     loading.value = true;
     const isClient = import.meta.env.VITE_IS_CLIENT === 'true';
+    const redirectUriBase = import.meta.env.VITE_SERVICE_URL || window.location.origin;
     const redirectUri = isClient
-      ? import.meta.env.VITE_GOOGLE_REDIRECT_URI_ELECTRON// Electron 主进程处理
-      : 'http://localhost:5005/api/users/auth/google'; 
+      ? import.meta.env.VITE_GOOGLE_REDIRECT_URI_ELECTRON // Electron 主进程处理
+      : `${redirectUriBase}/api/users/auth/google`;
     const clientId = '973572698649-hbp15ju1nhlsja1k2gbqktmrulk0hopp.apps.googleusercontent.com';
     const scope = encodeURIComponent('profile email');
     const responseType = 'code';
-    const googleAuthUrl = `https://accounts.google.com/o/oauth2/auth?client_id=${clientId}&redirect_uri=${redirectUri}&scope=${scope}&response_type=${responseType}&access_type=offline&prompt=consent`;
+    const encodedRedirect = encodeURIComponent(redirectUri);
+    const googleAuthUrl = `https://accounts.google.com/o/oauth2/auth?client_id=${clientId}&redirect_uri=${encodedRedirect}&scope=${scope}&response_type=${responseType}&access_type=offline&prompt=consent`;
     window.location.href = googleAuthUrl;
   } catch (error) {
     message.error(t('auth.googleLoginFailed'));

--- a/src/routers/user/users.js
+++ b/src/routers/user/users.js
@@ -90,7 +90,8 @@ router.get('/auth/google', async (ctx) => {
     `;
   } else {
     // 不是客户端，直接重定向到前端页面
-    const redirectUrl = `http://localhost:5005/#/auth/google${queryString ? '?' + queryString : ''}`;
+    const frontendOrigin = process.env.FRONTEND_ORIGIN || ctx.origin;
+    const redirectUrl = `${frontendOrigin}/#/auth/google${queryString ? '?' + queryString : ''}`;
     ctx.redirect(redirectUrl);
   }
 });


### PR DESCRIPTION
## Summary
- make redirect URI use configured API service URL when present
- encode redirect URI when building Google auth URL

## Testing
- `npm test` *(fails: mocha: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868cfcae6908321a507b184848d7e42